### PR TITLE
GraphObject overwriting GraphCollection

### DIFF
--- a/src/BaseGraphObject.php
+++ b/src/BaseGraphObject.php
@@ -36,7 +36,10 @@ class BaseGraphObject extends Collection
                 {
                     $items[$k] = new GraphCollection($v);
                 }
-                $items[$k] = new GraphObject($v['data']);
+                else
+                {
+                    $items[$k] = new GraphObject($v['data']);
+                }
             }
             elseif (is_array($v))
             {


### PR DESCRIPTION
Without the else statement, the GraphObject will overwrite the variable $items[$k] on every run no matter the ability to coerce the object to a valid Collection object. Currently this effectively performs the same function but wastes cycles and will eventually be a problem as metadata support, etc gets implemented into the Collection object.
