### PR TITLE
Maintenance for base library usage 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
   - 7.2
   - 7.3
+
+matrix:
+  include:
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_script:
   - composer install --prefer-source --no-interaction
 
 script:
-  - phpunit --coverage-text
+  - php vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 
 before_script:
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - composer install --prefer-source --no-interaction
 
 script:
   - phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ $fqb = new SammyK\FacebookQueryBuilder\FQB;
 $request = $fqb->node('me')
                ->fields(['id', 'email'])
                ->accessToken('user-access-token')
-               ->graphVersion('v3.1');
+               ->graphVersion('v3.3');
 
 echo $request;
-# https://graph.facebook.com/v3.1/me?access_token=user-access-token&fields=id,email
+# https://graph.facebook.com/v3.3/me?access_token=user-access-token&fields=id,email
 
 $response = file_get_contents((string) $request);
 
@@ -176,7 +176,7 @@ The recommended way to send requests & receive responses is to use the official 
 $fb = new Facebook\Facebook([
     'app_id' => 'your-app-id',
     'app_secret' => 'your-app-secret',
-    'default_graph_version' => 'v3.1',
+    'default_graph_version' => 'v3.3',
     ]);
 $fqb = new SammyK\FacebookQueryBuilder\FQB;
 
@@ -208,7 +208,7 @@ As you've already seen in the basic examples above, you can simply use PHP's fle
 
 ```php
 $fqb = new SammyK\FacebookQueryBuilder\FQB([
-    'default_graph_version' => 'v3.1',
+    'default_graph_version' => 'v3.3',
     'app_secret'            => 'your-app-secret',
 ]);
 
@@ -216,7 +216,7 @@ $fqb = new SammyK\FacebookQueryBuilder\FQB([
 $request = $fqb->node('4')->accessToken('my-access-token');
 
 echo $request;
-# https://graph.facebook.com/v3.1/4?access_token=my-access-token&appsecret_proof=2ad43b865030f51531ac36bb00ce4f59d9f879ecce31b0977dbfd73fa4eca7b6
+# https://graph.facebook.com/v3.3/4?access_token=my-access-token&appsecret_proof=2ad43b865030f51531ac36bb00ce4f59d9f879ecce31b0977dbfd73fa4eca7b6
 
 $response = file_get_contents((string) $request);
 
@@ -248,7 +248,7 @@ A number of configuration settings can be set via the `FQB` constructor.
 ```php
 $fqb = new SammyK\FacebookQueryBuilder\FQB([
     'default_access_token'  => 'your-access-token',
-    'default_graph_version' => 'v3.1',
+    'default_graph_version' => 'v3.3',
     'app_secret'            => 'your-app-secret',
 ]);
 ```
@@ -285,12 +285,12 @@ If you're using some other HTTP client, you can set the default fallback Graph v
 
 ```php
 $fqb = new SammyK\FacebookQueryBuilder\FQB([
-    'default_graph_version' => 'v3.1',
+    'default_graph_version' => 'v3.3',
 ]);
 
 $request = $fqb->node('me');
 echo $request->asEndpoint();
-# /v3.1/me
+# /v3.3/me
 
 $request = $fqb->node('me')->graphVersion('v1.0');
 echo $request->asEndpoint();
@@ -403,7 +403,7 @@ modifiers(array $modifiers): FQB
 
 Some endpoints of the Graph API support additional parameters called "modifiers".
 
-An example endpoint that supports modifiers is the [`/{object-id}/comments` edge](https://developers.facebook.com/docs/graph-api/reference/v3.1/object/comments#readmodifiers).
+An example endpoint that supports modifiers is the [`/{object-id}/comments` edge](https://developers.facebook.com/docs/graph-api/reference/v3.3/object/comments#readmodifiers).
 
 ```php
 // Order the comments in chronological order
@@ -456,10 +456,10 @@ graphVersion(string $graphApiVersion): FQB
 You can set the Graph version URL prefix for a specific request with the `graphVersion()` method.
 
 ```php
-$request = $fqb->node('me')->graphVersion('v3.1');
+$request = $fqb->node('me')->graphVersion('v3.3');
 
 echo $request->asEndpoint();
-# /v3.1/me
+# /v3.3/me
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,11 @@
     },
     "autoload": {
         "psr-4": {
-            "SammyK\\FacebookQueryBuilder\\": "src",
+            "SammyK\\FacebookQueryBuilder\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "SammyK\\FacebookQueryBuilderTests\\": "tests"
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "~4.0 || ~5.0",
         "squizlabs/php_codesniffer": "~2.0"
     },
     "autoload": {


### PR DESCRIPTION
Just a quick touch of maintenance for:
1. Travis: the trusty distribution is now required to install PHP <= 5.5, see https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723
2. PHPUnit: from PHP 7.2 the usage of PHPUnit v4 will give warnings, PHPUnit v5 is still compatible with current tests and won't give messages
3. exclude tests from production autoload, those shouldn't be available at all
4. bump for current graph version

I hope you will appreciate ✌️